### PR TITLE
fix/show name if choices are objects

### DIFF
--- a/examples/objects.js
+++ b/examples/objects.js
@@ -1,0 +1,35 @@
+"use strict";
+const inquirer = require("inquirer");
+
+// Register plugin
+inquirer.registerPrompt("search-list", require("../dist"));
+
+const toppings = [
+  {title: "Pepperoni", usage: "Pizza"},
+  {title: "Ham", usage: "Sandwich"},
+  {title: "Ground Meat", usage: "BBQ"},
+  {title: "Bacon", usage: "Love"},
+  {title: "Bottle", usage: "Drinks"},
+  {title: "Mozzarella", usage: "Pizza"},
+  {title: "Rum", usage: "Party"},
+]
+
+inquirer
+    .prompt([
+        {
+            type: "search-list",
+            message: "Select topping",
+            name: "topping",
+            choices: toppings.map(topping => ({name: topping.title, value: topping })),
+            validate: function(answer) {
+                if (answer.name === 'Bottle') {
+                    return `Whoops, ${answer.name} is not a real topping.`;
+                }
+                return true;
+            }
+        }
+    ])
+    .then(function(answers) {
+        console.log(JSON.stringify(answers, null, "  "));
+    })
+    .catch(e => console.log(e));

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ function renderChoices(choices: Item[], pointer: number) {
 
 class SearchBox extends Base {
 	private pointer: number = 0;
-	private selected: string | undefined = '';
+	private selected: string |undefined = '';
 	// @ts-ignore
         private done: (state: any) => void;
 	private list: Item[] = [];
@@ -108,8 +108,8 @@ class SearchBox extends Base {
 
 	onEnd(state: any) {
 		this.status = "answered";
-                if(this.getCurrentValue()) {
-                    this.selected = this.getCurrentValue()
+                if(this.getCurrentItemName()) {
+                    this.selected = this.getCurrentItemName()
                 }
 		// Rerender prompt (and clean subline error)
 		this.render();
@@ -128,18 +128,26 @@ class SearchBox extends Base {
 		this.render();
 	}
 
-	getCurrentValue() {
-            if(this.filterList.length) {
-                return this.filterList[this.pointer].value
-            } else {
-		return this.list[this.pointer].value
-            }
-	}
+	getCurrentItem() {
+    if(this.filterList.length) {
+        return this.filterList[this.pointer]
+    } else {
+		  return this.list[this.pointer]
+    }
+  }
+
+  getCurrentItemValue() {
+    return this.getCurrentItem().value
+  }
+
+  getCurrentItemName(){
+    return this.getCurrentItem().name
+  }
 
 	_run(cb: any) {
 		this.done = cb;
 
-		const events = observe(this.rl);
+    const events = observe(this.rl);
 		const upKey = events.keypress.filter(
 			(e: Event) =>
 				e.key.name === "up" || (e.key.name === "p" && e.key.ctrl)
@@ -152,7 +160,7 @@ class SearchBox extends Base {
 			(e: Event) => e.key.name === "o" && e.key.ctrl
 		);
 		const validation = this.handleSubmitEvents(
-			events.line.map(this.getCurrentValue.bind(this))
+			events.line.map(this.getCurrentItemValue.bind(this))
 		);
 
 		validation.success.forEach(this.onEnd.bind(this));


### PR DESCRIPTION
# Summary

Hey man, great work on this plugin. I found a possible small issue and submitted a PR. Let me know what do you think.

**Bug:** shows `[object Object]` as the selected choice if choices are objects

![bug](https://user-images.githubusercontent.com/2616517/89461933-ac7a6980-d73a-11ea-9086-b2ce4d4380db.gif)

**Expected** `choice.name` is shown

![success](https://user-images.githubusercontent.com/2616517/89461944-af755a00-d73a-11ea-8cb3-086d015f80b3.gif)

## Commits

- Print selected choice name if choices are objects
- Add an example that uses objects as choices

## Suggested test cases

1. Should show selected choice name if prompt choices are valid objects
2. Should return the selected choice object if prompt choices are valid objects
3. Should show selected choice if prompt choices are strings
4. Should return selected choice if prompt choices are strings

## Questions

Are you open to adding tests using `mocha/chai` or similar?


