### PR TITLE
DRAFT Add further customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^2.5.3"
   },
   "dependencies": {
-    "chalk": "^2.3.0",
+    "chalk": "^2.4.2",
     "figures": "^2.0.0",
     "fuzzy": "^0.1.3",
     "inquirer": "^3.3.0"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,8 @@ declare module "inquirer/lib/prompts/base" {
 		opt: {
 			choices: Base.Item[];
 			pageSize: number;
+      renderRow: (item: Base.Item, isSelected: boolean) => string;
+      filterRow: (item: Base.Item, query: string) => boolean;
 		};
 		rl: {
 			line: string;


### PR DESCRIPTION
This change allows customizing the way matching and rendering is done. I'd be happy to clean it up and change the API surface to make this mergeable, but I added this to make a use case of mine possible. Here's what my consumer does using these new features:

```javascript
const renderRow = (item, isSelected) => {
  const post = item.value;
  if (isSelected) {
    return `${chalk.cyan(figures.pointer)}${chalk.cyan(post.description)} (${chalk.white(url.parse(post.href).hostname)}) [${post.tags.split(' ').join(', ')}]`
  } else {
    return ` ${post.description} (${chalk.dim(url.parse(post.href).hostname)})`
  }
}

const filterSet = (list, query) => {
  list = list.filter((item) => filterOutUntagged(item, query))
  let fuse = new Fuse(list, { keys: ['name'] })
  return fuse.search(query).map((i) => i.item)
}

const filterOutUntagged = ({ value: post }, query) => {
  const desiredTags = query.split(' ').filter((subQuery) => subQuery[0] === '+')
  const queryMinusTags = query.split(' ').filter((subQuery) => subQuery[0] !== '+').join('')
  const actualTags = post.tags.split(' ')
  const validTags =
    desiredTags.every((desiredTag) => actualTags.some((actualTag) => fuzzy.test(desiredTag.slice(1), actualTag)))
  if (validTags) {
    return true
    // fuzzy.test(queryMinusTags, `${post.description} ${url.parse(post.href).hostname}`)
  } else {
    return false
  }
}

const promptUser = async (db) => {
  return inquirer
    .prompt([{
      type: 'search-list',
      message: 'Select a link',
      name: 'link',
      // we just overwrite name anyway in renderRow, not sure why it exists...
      choices: db.map((post) => { return { name: post.description, value: post } }),
      renderRow,
      filterSet
    }])
    .then((answers) => {
      open(answers.link.href)
    })
    .catch((error) => console.log(error))
}

```