### PR TITLE
Remove space key from ignoredKeys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ interface Item extends Base.Item {
 	id: number;
 }
 
-const ignoreKeys = ["up", "down", "space"];
+const ignoreKeys = ["up", "down"];
 
 function defaultFilterRow(choice: Item, query: string) {
   return fuzzy.test(query, choice.name);


### PR DESCRIPTION
I think it's confusing that the space key is being ignored completely - the UI will not re-render when space is pressed, so the cursor is not moved to the correct position. This is especially noticable when trying to add spaces at a middle position of the search input.